### PR TITLE
Print modbus error for debugging

### DIFF
--- a/src/MPA.cpp
+++ b/src/MPA.cpp
@@ -35,7 +35,7 @@ MPA::~MPA() {
 
 bool MPA::connect() {
     if (modbus_connect(ctx_) == -1) {
-        fprintf(stderr, "Connection failed");//: %s\n", modbus_strerror(errno));
+        fprintf(stderr, "Connection failed: %s\n", modbus_strerror(errno));
         modbus_free(ctx_);
         connected_ = false;
         return false;


### PR DESCRIPTION
Print modbus error for debugging

Was useful when we needed to debug an IP clash error