### PR TITLE
update qualisys_cpp_sdk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(include)
 
 ### compile the submodules
 set(BUILD_EXAMPLES true) # this is read by the CMake file in qualisys_cpp_sdk
+set(qualisys_cpp_sdk_OUTPUT_TYPE SHARED)
 add_subdirectory(subm/qualisys_cpp_sdk)
 
 add_subdirectory(subm/fmt)

--- a/src/QualisysClient.cpp
+++ b/src/QualisysClient.cpp
@@ -106,7 +106,7 @@ bool QualisysClient::connect_and_setup() {
     }
 
 
-    while (!rtProtocol.StreamFrames(CRTProtocol::RateAllFrames, 0, udpPort, NULL, str.c_str())) {
+    while (!rtProtocol.StreamFrames(CRTProtocol::EStreamRate::RateAllFrames, 0, udpPort, NULL, str.c_str())) {
         printf("rtProtocol.StreamFrames: %s\n\n", rtProtocol.GetErrorString());
         srl::sleep(1);
     }


### PR DESCRIPTION
use more recent version of qualisys_cpp_sdk to resolve error:
```
r/RigidBodyStreaming/RigidBodyStreaming.cpp.o
In file included from /home/yasu/3d-soft-trunk/mobilerack-interface/subm/qualisys_cpp_sdk/RigidBodyStreaming/RigidBodyStreaming.cpp:1:
/home/yasu/3d-soft-trunk/mobilerack-interface/subm/qualisys_cpp_sdk/RTProtocol.h:195:9: error: ‘uint32_t’ does not name a type
  195 |         uint32_t physicalId;
```

tweak some of the code to make it work with qualisys_cpp_sdk again, as it caused an error:
```
(venv) (base) ➜  3d-soft-trunk git:(master) ✗ make
[ 25%] Built target yaml-cpp
[ 27%] Built target fmt
[ 35%] Built target qualisys_cpp_sdk
[ 36%] Linking CXX shared library ../lib/libQualisysClient.so
/usr/bin/ld: ../lib/libqualisys_cpp_sdk.a(tinyxml2.cpp.o): warning: relocation against stdout@@GLIBC_2.2.5' in read-only section .text'
/usr/bin/ld: ../lib/libqualisys_cpp_sdk.a(RTProtocol.cpp.o): relocation R_X86_64_PC32 against symbol __libc_single_threaded@@GLIBC_2.32' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [mobilerack-interface/CMakeFiles/QualisysClient.dir/build.make:154: lib/libQualisysClient.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:954: mobilerack-interface/CMakeFiles/QualisysClient.dir/all] Error 2
make: *** [Makefile:136: all] Error 
```

fixed by setting `set(qualisys_cpp_sdk_OUTPUT_TYPE SHARED)`, seen in https://github.com/qualisys/qualisys_cpp_sdk/pull/113 and https://github.com/qualisys/qualisys_cpp_sdk/pull/119